### PR TITLE
fix typo in _needDrain flag

### DIFF
--- a/block-stream.js
+++ b/block-stream.js
@@ -151,7 +151,7 @@ BlockStream.prototype._emitChunk = function (flush) {
   this._buffer = this._buffer.slice(bufferIndex)
   if (this._paused) {
     // debug("    BS paused, leaving", this._bufferLength)
-    this._needsDrain = true
+    this._needDrain = true
     this._emitting = false
     return
   }


### PR DESCRIPTION
typo sets a flag that never gets used
